### PR TITLE
small change for mingw

### DIFF
--- a/NativeAPI.h
+++ b/NativeAPI.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 #define STATUS_SUCCESS 0
 #define STATUS_UNSUCCESSFUL 0xC0000001


### PR DESCRIPTION
I received the follwing error when compiling with mingw. This should fix it.
```
x86_64-w64-mingw32-gcc -o FindProcHandle.o -c FindProcHandle.c -masm=intel
In file included from FindProcHandle.c:4:
NativeAPI.h:3:10: fatal error: Windows.h: No such file or directory
    3 | #include <Windows.h>
      |          ^~~~~~~~~~~
compilation terminated.
```